### PR TITLE
Add hash-routing to the app for sharable links that work with iOS PWAs in the SPA paradigm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prairie-wx",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prairie-wx",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "dependencies": {
         "@hono/node-server": "^1.14.3",
         "@hono/zod-validator": "^0.7.0",
@@ -37,7 +37,6 @@
         "react-dom": "^19.1.0",
         "react-map-gl": "^8.0.4",
         "react-router": "^7.6.2",
-        "react-router-dom": "^7.6.2",
         "sonner": "^2.0.4",
         "suncalc": "^1.9.0",
         "vaul": "^1.1.2",
@@ -11427,22 +11426,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
-      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-dom": "^19.1.0",
         "react-map-gl": "^8.0.4",
         "react-router": "^7.6.2",
+        "react-router-dom": "^7.6.2",
         "sonner": "^2.0.4",
         "suncalc": "^1.9.0",
         "vaul": "^1.1.2",
@@ -11426,6 +11427,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-map-gl": "^8.0.4",
+        "react-router": "^7.6.2",
         "sonner": "^2.0.4",
         "suncalc": "^1.9.0",
         "vaul": "^1.1.2",
@@ -7632,6 +7633,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
@@ -11396,6 +11406,28 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -11794,6 +11826,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "compile": "tsc -b",
     "build": "vite build && tsc -b",
-    "deploy": "pm2 stop beta.config.cjs && git stash && git pull && git checkout dev && npm install --include=dev && npm run build && pm2 start beta.config.cjs --env production"
+    "deploy": "pm2 stop beta.config.cjs && git stash && git pull --rebase && npm install --include=dev && npm run build && pm2 start beta.config.cjs --env production"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-map-gl": "^8.0.4",
+    "react-router": "^7.6.2",
     "sonner": "^2.0.4",
     "suncalc": "^1.9.0",
     "vaul": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-dom": "^19.1.0",
     "react-map-gl": "^8.0.4",
     "react-router": "^7.6.2",
+    "react-router-dom": "^7.6.2",
     "sonner": "^2.0.4",
     "suncalc": "^1.9.0",
     "vaul": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prairie-wx",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": true,
   "type": "module",
   "main": "main.js",
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "compile": "tsc -b",
     "build": "vite build && tsc -b",
-    "deploy": "pm2 stop beta.config.cjs && git stash && git pull --rebase && npm install --include=dev && npm run build && pm2 start beta.config.cjs --env production"
+    "deploy": "git stash && git pull --rebase && npm install --include=dev && npm run build && pm2 restart beta.config.cjs --env production"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
@@ -67,7 +67,6 @@
     "react-dom": "^19.1.0",
     "react-map-gl": "^8.0.4",
     "react-router": "^7.6.2",
-    "react-router-dom": "^7.6.2",
     "sonner": "^2.0.4",
     "suncalc": "^1.9.0",
     "vaul": "^1.1.2",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,6 @@
 // third-party libraries
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router";
 
 // ui components
 import Button from "@/components/ui/Button";
@@ -21,6 +23,31 @@ const appModesList: AppMode[] = Object.keys(APP_MODES_LIST).map((k) => k as AppM
 export const App = () => {
   const appMode = useAppMode();
   const setAppMode = useSetAppMode();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // handle app mode base on the URL hash path
+  // we are using the hash path to determine the app mode
+  // and allow us to create a sharable URL without breaking
+  // the iOS SPA PWA experience
+  useEffect(() => {
+    const hashMode = location.pathname.replace("/", "") as AppMode;
+
+    // if the hash mode is set, valid, and different from the current app mode, set the app mode
+    if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
+      setAppMode(hashMode);
+    } else if (!hashMode && appMode) {
+      navigate(`/${appMode}`, { replace: true });
+    }
+  }, [location.pathname]);
+
+  // handle the app mode when a user clicks on one of the app mode tabs
+  const handleSetAppMode = (mode: AppMode) => {
+    if (mode !== appMode) {
+      setAppMode(mode);
+      navigate(`/${mode}`, { replace: true });
+    }
+  };
 
   return (
     <main className="w-full max-w-(--breakpoint-2xl) mx-auto">
@@ -28,7 +55,12 @@ export const App = () => {
       <nav className="flex justify-between px-4 mt-2 place-items-center max-md:hidden">
         <img src="/site-icon.svg" className="w-10 h-10 inline me-2" />
         {appModesList.map((l, i) => (
-          <Button key={i} variant={"menuTab"} className={appMode === l ? "active " : ""} onClick={() => setAppMode(l)}>
+          <Button
+            key={i}
+            variant={"menuTab"}
+            className={appMode === l ? "active " : ""}
+            onClick={() => handleSetAppMode(l)}
+          >
             {APP_MODES_LIST[l].longName}
           </Button>
         ))}
@@ -38,7 +70,12 @@ export const App = () => {
       <nav className="flex justify-between px-2 place-items-center md:hidden ">
         <img src="/site-icon.svg" className="w-6 h-6 inline" />
         {appModesList.map((l, i) => (
-          <Button key={i} variant={"menuTab"} className={appMode === l ? "active " : ""} onClick={() => setAppMode(l)}>
+          <Button
+            key={i}
+            variant={"menuTab"}
+            className={appMode === l ? "active " : ""}
+            onClick={() => handleSetAppMode(l)}
+          >
             {APP_MODES_LIST[l].shortName}
           </Button>
         ))}
@@ -52,8 +89,6 @@ export const App = () => {
       {appMode === "otlk" && <Outlooks />}
 
       <Toaster toastOptions={{ className: "bg-neutral-800 text-white" }} />
-
-      {/* <ReactQueryDevtools /> */}
     </main>
   );
 };

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -44,7 +44,7 @@ export const App = () => {
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`/`, { replace: true, relative: "route" });
+      navigate(`../`, { replace: true, relative: "route" });
     }
   }, [location.pathname, location.hash]);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,40 +31,22 @@ export const App = () => {
   // we are using the hash path to determine the app mode
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
-  // useEffect(() => {
-  //   const hashMode = location.pathname.replace("/", "") as AppMode;
-
-  //   setCount(count + 1);
-
-  //   console.log(count, location.pathname, location.hash, hashMode, appMode);
-
-  //   // if the hash mode is set, valid, and different from the current app mode, set the app mode
-  //   if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
-  //     setAppMode(hashMode);
-  //   } else if (!hashMode && appMode) {
-  //     navigate(`/${appMode}`, { replace: true });
-  //   }
-  // }, [location.pathname, location.hash]);
-
   useEffect(() => {
-    // Only handle appMode if we're at the SPA root (after nginx redirect)
+    const hashMode = location.pathname.replace("/", "") as AppMode;
 
     setCount(count + 1);
 
-    console.log(count, location.pathname, location.hash, "hashModeHere", appMode);
-
-    if (location.pathname !== "/") return;
-
-    const hashMode = location.hash.replace(/^#\/?/, "") as AppMode;
-
     console.log(count, location.pathname, location.hash, hashMode, appMode);
 
+    // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
+      console.log("setting app mode");
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
+      console.log("navigating");
       navigate(`/${appMode}`, { replace: true });
     }
-  }, [location.pathname, location.hash]);
+  }, [location.pathname]);
 
   // handle the app mode when a user clicks on one of the app mode tabs
   const handleSetAppMode = (mode: AppMode) => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,5 +1,5 @@
 // third-party libraries
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 
 // ui components
@@ -25,6 +25,7 @@ export const App = () => {
   const setAppMode = useSetAppMode();
   const location = useLocation();
   const navigate = useNavigate();
+  const [count, setCount] = useState(0);
 
   // handle app mode base on the URL hash path
   // we are using the hash path to determine the app mode
@@ -33,7 +34,9 @@ export const App = () => {
   useEffect(() => {
     const hashMode = location.pathname.replace("/", "") as AppMode;
 
-    console.log(location.pathname, location.hash, hashMode);
+    console.log(count, location.pathname, location.hash, hashMode);
+
+    setCount(count + 1);
 
     // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,6 @@
 // third-party libraries
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 
 // ui components
 import Button from "@/components/ui/Button";
@@ -36,7 +36,7 @@ export const App = () => {
 
     setCount(count + 1);
 
-    console.log(count, location.pathname, location.hash, appMode);
+    console.log(count, location.pathname, hashMode, appMode);
 
     // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -49,6 +49,8 @@ export const App = () => {
   useEffect(() => {
     // Only handle appMode if we're at the SPA root (after nginx redirect)
 
+    setCount(count + 1);
+
     console.log(count, location.pathname, location.hash, "hashModeHere", appMode);
 
     if (location.pathname !== "/") return;

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,6 @@
 // third-party libraries
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router-dom";
 
 // ui components
 import Button from "@/components/ui/Button";
@@ -34,15 +34,15 @@ export const App = () => {
   useEffect(() => {
     const hashMode = location.pathname.replace("/", "") as AppMode;
 
-    console.log(count, location.pathname, location.hash, hashMode);
-
     setCount(count + 1);
+
+    console.log(count, location.pathname, location.hash, appMode);
 
     // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`../${appMode}`, { replace: true, relative: "route" });
+      navigate(`/${appMode}`, { replace: true });
     }
   }, [location.pathname, location.hash]);
 
@@ -50,7 +50,7 @@ export const App = () => {
   const handleSetAppMode = (mode: AppMode) => {
     if (mode !== appMode) {
       setAppMode(mode);
-      navigate(`../${mode}`, { replace: true, relative: "route" });
+      navigate(`/${mode}`, { replace: true });
     }
   };
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -26,14 +26,19 @@ export const App = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  console.log(sessionStorage.getItem("ignoreHashOnce"));
-
   // handle app mode base on the URL hash path
   // we are using the hash path to determine the app mode
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
+  // the nginx config on the server uses a 302 redirect to take any URL that points to /[appModesList]
+  // and convert it to a /#/[appModesList] URL, which is then handled by this code
   useEffect(() => {
-    // Only run this logic once per session
+    // this is a hack to allow iOS PWA users to have their app mode set when they first open the app
+    // this is necessary because when they add the app to their home screen,
+    // the app will reference whatever the their app mode was when they created the shortcut
+    // we're using sessionStorage to set a flag to ignore the hash path once and stop the
+    // redirect that would otherwise happen; this flag is cleared when the app is force-closed
+    // or the app is ended by iOS internal memory management
     if (!sessionStorage.getItem("ignoreHashOnce")) {
       if (location.pathname !== "/" && location.pathname !== "") {
         // Remove the hash path and go to the appMode in localStorage
@@ -43,11 +48,15 @@ export const App = () => {
       }
     }
 
+    // get our hash mode from the URL path
+    // using HashRouter means that 'pathname' will be, compltely unintuitively(!)
+    //  the hash path, while 'hash' is actually empty (lol)
     const hashMode = location.pathname.replace("/", "") as AppMode;
 
     // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
+      // otherwise if there's no hashMode but we have an appMode, navigate to that app mode
     } else if (!hashMode && appMode) {
       navigate(`/${appMode}`, { replace: true });
     }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -26,11 +26,23 @@ export const App = () => {
   const location = useLocation();
   const navigate = useNavigate();
 
+  console.log(sessionStorage.getItem("ignoreHashOnce"));
+
   // handle app mode base on the URL hash path
   // we are using the hash path to determine the app mode
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
   useEffect(() => {
+    // Only run this logic once per session
+    if (!sessionStorage.getItem("ignoreHashOnce")) {
+      if (location.pathname !== "/" && location.pathname !== "") {
+        // Remove the hash path and go to the appMode in localStorage
+        sessionStorage.setItem("ignoreHashOnce", "true");
+        navigate(`/${appMode}`, { replace: true });
+        return;
+      }
+    }
+
     const hashMode = location.pathname.replace("/", "") as AppMode;
 
     // if the hash mode is set, valid, and different from the current app mode, set the app mode

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -48,9 +48,14 @@ export const App = () => {
 
   useEffect(() => {
     // Only handle appMode if we're at the SPA root (after nginx redirect)
+
+    console.log(count, location.pathname, location.hash, "hashModeHere", appMode);
+
     if (location.pathname !== "/") return;
 
     const hashMode = location.hash.replace(/^#\/?/, "") as AppMode;
+
+    console.log(count, location.pathname, location.hash, hashMode, appMode);
 
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,6 @@
 // third-party libraries
-import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router";
 
 // ui components
 import Button from "@/components/ui/Button";
@@ -25,7 +25,6 @@ export const App = () => {
   const setAppMode = useSetAppMode();
   const location = useLocation();
   const navigate = useNavigate();
-  const [count, setCount] = useState(0);
 
   // handle app mode base on the URL hash path
   // we are using the hash path to determine the app mode
@@ -34,16 +33,10 @@ export const App = () => {
   useEffect(() => {
     const hashMode = location.pathname.replace("/", "") as AppMode;
 
-    setCount(count + 1);
-
-    console.log(count, location.pathname, location.hash, hashMode, appMode);
-
     // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
-      console.log("setting app mode");
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      console.log("navigating");
       navigate(`/${appMode}`, { replace: true });
     }
   }, [location.pathname]);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,6 @@
 // third-party libraries
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router-dom";
 
 // ui components
 import Button from "@/components/ui/Button";
@@ -31,18 +31,31 @@ export const App = () => {
   // we are using the hash path to determine the app mode
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
+  // useEffect(() => {
+  //   const hashMode = location.pathname.replace("/", "") as AppMode;
+
+  //   setCount(count + 1);
+
+  //   console.log(count, location.pathname, location.hash, hashMode, appMode);
+
+  //   // if the hash mode is set, valid, and different from the current app mode, set the app mode
+  //   if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
+  //     setAppMode(hashMode);
+  //   } else if (!hashMode && appMode) {
+  //     navigate(`/${appMode}`, { replace: true });
+  //   }
+  // }, [location.pathname, location.hash]);
+
   useEffect(() => {
-    const hashMode = location.pathname.replace("/", "") as AppMode;
+    // Only handle appMode if we're at the SPA root (after nginx redirect)
+    if (location.pathname !== "/") return;
 
-    setCount(count + 1);
+    const hashMode = location.hash.replace(/^#\/?/, "") as AppMode;
 
-    console.log(count, location.pathname, hashMode, appMode);
-
-    // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`/${appMode}`, { replace: true });
+      navigate(`/#/${appMode}`, { replace: true });
     }
   }, [location.pathname, location.hash]);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,12 +31,12 @@ export const App = () => {
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
   useEffect(() => {
-    console.log("hi there useEffect");
+    console.log("hi there useEffect", location.pathname, location.hash);
     // If the user lands on a path like /obs (not /), do nothing and let nginx redirect to /#/obs
     if (location.pathname !== "/") return;
 
     // Now we're at /, so use the hash as the source of truth
-    const hashMode = location.hash.replace("#/", "") as AppMode;
+    const hashMode = location.pathname.replace("/", "") as AppMode;
 
     console.log(location.pathname, location.hash, hashMode);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,11 +31,6 @@ export const App = () => {
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
   useEffect(() => {
-    console.log("hi there useEffect", location.pathname, location.hash);
-    // If the user lands on a path like /obs (not /), do nothing and let nginx redirect to /#/obs
-    if (location.pathname !== "/") return;
-
-    // Now we're at /, so use the hash as the source of truth
     const hashMode = location.pathname.replace("/", "") as AppMode;
 
     console.log(location.pathname, location.hash, hashMode);
@@ -44,7 +39,7 @@ export const App = () => {
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`../`, { replace: true, relative: "route" });
+      navigate(`../${appMode}`, { replace: true, relative: "route" });
     }
   }, [location.pathname, location.hash]);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -44,7 +44,7 @@ export const App = () => {
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`../${appMode}`, { replace: true, relative: "route" });
+      navigate(`/`, { replace: true, relative: "route" });
     }
   }, [location.pathname, location.hash]);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -36,7 +36,7 @@ export const App = () => {
     if (location.pathname !== "/") return;
 
     // Now we're at /, so use the hash as the source of truth
-    const hashMode = location.pathname.replace("#/", "") as AppMode;
+    const hashMode = location.hash.replace("#/", "") as AppMode;
 
     console.log(location.pathname, location.hash, hashMode);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -36,7 +36,7 @@ export const App = () => {
     if (location.pathname !== "/") return;
 
     // Now we're at /, so use the hash as the source of truth
-    const hashMode = location.hash.replace("#/", "") as AppMode;
+    const hashMode = location.pathname.replace("#/", "") as AppMode;
 
     console.log(location.pathname, location.hash, hashMode);
 
@@ -44,7 +44,7 @@ export const App = () => {
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`/#/${appMode}`, { replace: true });
+      navigate(`../${appMode}`, { replace: true, relative: "route" });
     }
   }, [location.pathname, location.hash]);
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -31,15 +31,22 @@ export const App = () => {
   // and allow us to create a sharable URL without breaking
   // the iOS SPA PWA experience
   useEffect(() => {
-    const hashMode = location.pathname.replace("/", "") as AppMode;
+    console.log("hi there useEffect");
+    // If the user lands on a path like /obs (not /), do nothing and let nginx redirect to /#/obs
+    if (location.pathname !== "/") return;
+
+    // Now we're at /, so use the hash as the source of truth
+    const hashMode = location.hash.replace("#/", "") as AppMode;
+
+    console.log(location.pathname, location.hash, hashMode);
 
     // if the hash mode is set, valid, and different from the current app mode, set the app mode
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`/${appMode}`, { replace: true });
+      navigate(`/#/${appMode}`, { replace: true });
     }
-  }, [location.pathname]);
+  }, [location.pathname, location.hash]);
 
   // handle the app mode when a user clicks on one of the app mode tabs
   const handleSetAppMode = (mode: AppMode) => {
@@ -89,6 +96,8 @@ export const App = () => {
       {appMode === "otlk" && <Outlooks />}
 
       <Toaster toastOptions={{ className: "bg-neutral-800 text-white" }} />
+
+      {/* <ReactQueryDevtools /> */}
     </main>
   );
 };

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -52,7 +52,7 @@ export const App = () => {
   const handleSetAppMode = (mode: AppMode) => {
     if (mode !== appMode) {
       setAppMode(mode);
-      navigate(`/${mode}`, { replace: true });
+      navigate(`../${mode}`, { replace: true, relative: "route" });
     }
   };
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -62,7 +62,7 @@ export const App = () => {
     if (hashMode && hashMode !== appMode && appModesList.includes(hashMode)) {
       setAppMode(hashMode);
     } else if (!hashMode && appMode) {
-      navigate(`/#/${appMode}`, { replace: true });
+      navigate(`/${appMode}`, { replace: true });
     }
   }, [location.pathname, location.hash]);
 
@@ -70,7 +70,7 @@ export const App = () => {
   const handleSetAppMode = (mode: AppMode) => {
     if (mode !== appMode) {
       setAppMode(mode);
-      navigate(`/#/${mode}`, { replace: true });
+      navigate(`/${mode}`, { replace: true });
     }
   };
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -63,7 +63,7 @@ export const App = () => {
   const handleSetAppMode = (mode: AppMode) => {
     if (mode !== appMode) {
       setAppMode(mode);
-      navigate(`/${mode}`, { replace: true });
+      navigate(`/#/${mode}`, { replace: true });
     }
   };
 

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom/client";
 import { StrictMode } from "react";
-import { HashRouter } from "react-router";
+import { HashRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./index.css";

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom/client";
 import { StrictMode } from "react";
-import { HashRouter } from "react-router-dom";
+import { HashRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./index.css";

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom/client";
 import { StrictMode } from "react";
-
+import { HashRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./index.css";
@@ -15,7 +15,9 @@ if (!rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <HashRouter>
+          <App />
+        </HashRouter>
       </QueryClientProvider>
     </StrictMode>,
   );

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom/client";
 import { StrictMode } from "react";
-import { HashRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./index.css";
@@ -15,9 +15,9 @@ if (!rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <HashRouter>
+        <BrowserRouter>
           <App />
-        </HashRouter>
+        </BrowserRouter>
       </QueryClientProvider>
     </StrictMode>,
   );

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,6 +1,6 @@
 import ReactDOM from "react-dom/client";
 import { StrictMode } from "react";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./index.css";
@@ -15,9 +15,9 @@ if (!rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </QueryClientProvider>
     </StrictMode>,
   );


### PR DESCRIPTION
This was a pain in the ass, but mostly because of browser caching and repeatedly hitting the same URL.

Problems addressed:

1. Sharable links were ugly: `/#/otlk` isn't user friendly, so via server config we are redirecting `/otlk` to `/#/otlk`, which triggers internal app state updates. Better social media usability this way.
2. URL state and localStorage state needed to be sync'd: There is a `useEffect` added to the `<App />` component to allow for this to occur
3. iOS PWA support: huge pain in the ass with saving the app to the homescreen, it would always keep the hash path for whatever mode the app was 'saved' in. I added a flag to sessionStorage to ignore that hash path on first load and use localStorage as the default.

KNOWN ISSUES:

If a user is redirected on their first visit of a session, they will revert back to their default from localStorage. This needs to be resolved via some _other_ flag, maybe redirecting with a queryParam added and then skipping that in the sessionStorage flag setting?